### PR TITLE
docs: update URLs after org transfer to baker-scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,5 +32,5 @@ docker run -d \
   -e APPRISE_URLS="your-apprise-urls-separated-by-commas" \
   -e AUTODNS_PORT=4295 \
   -e AUTODNS_HOST=0.0.0.0 \
-  ghcr.io/bakerboy448/autodns:develop
+  ghcr.io/baker-scripts/autodns:develop
 ```

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -1,6 +1,6 @@
 services:
   autodns:
-    image: ghcr.io/bakerboy448/autodns:develop
+    image: ghcr.io/baker-scripts/autodns:develop
     ports:
     - "4295:4295"
     volumes:


### PR DESCRIPTION
## Summary
- Update `ghcr.io/bakerboy448/autodns` to `ghcr.io/baker-scripts/autodns` in README.md and docker-compose.example.yml

## Files Changed
- `README.md` - Docker run example image reference
- `docker-compose.example.yml` - Compose image reference

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated Docker image registry reference from `ghcr.io/bakerboy448/autodns:develop` to `ghcr.io/baker-scripts/autodns:develop` in documentation and example Docker Compose configuration. Users should update their container image references accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->