### PR TITLE
fix: update GHCR references from bakerboy448 to baker-scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,5 +32,5 @@ docker run -d \
   -e APPRISE_URLS="your-apprise-urls-separated-by-commas" \
   -e AUTODNS_PORT=4295 \
   -e AUTODNS_HOST=0.0.0.0 \
-  ghcr.io/bakerboy448/autodns:develop
+  ghcr.io/baker-scripts/autodns:develop
 ```

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -1,6 +1,6 @@
 services:
   autodns:
-    image: ghcr.io/bakerboy448/autodns:develop
+    image: ghcr.io/baker-scripts/autodns:develop
     ports:
     - "4295:4295"
     volumes:


### PR DESCRIPTION
## Summary
- Update GHCR image references in README.md and docker-compose.example.yml
- `ghcr.io/bakerboy448/autodns` → `ghcr.io/baker-scripts/autodns`

## Context
Repo was transferred from bakerboy448 to baker-scripts org. GHCR packages don't transfer automatically, so image references need updating to match the new org namespace.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker image registry references for the autodns service deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->