### PR TITLE
feat: add OCI image labels to Dockerfile

### DIFF
--- a/DOCKERFILE
+++ b/DOCKERFILE
@@ -1,6 +1,16 @@
 # Use an updated and specific version of the Python image
 FROM python:3.11-slim-bullseye
 
+# OCI Labels
+LABEL org.opencontainers.image.title="AutoDNS" \
+      org.opencontainers.image.description="Lightweight DNS updater — automatically syncs Cloudflare DNS records via GUID-based identification" \
+      org.opencontainers.image.authors="baker-scripts" \
+      org.opencontainers.image.source="https://github.com/baker-scripts/autodns" \
+      org.opencontainers.image.documentation="https://github.com/baker-scripts/autodns/blob/develop/README.md" \
+      org.opencontainers.image.licenses="GPL-3.0" \
+      org.opencontainers.image.vendor="baker-scripts" \
+      org.opencontainers.image.base.name="python:3.11-slim-bullseye"
+
 # Define work directory
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
- Add standard OCI image labels to DOCKERFILE for container registry metadata
- Includes: title, description, authors, source, documentation, licenses, vendor, base image

Matches the label standard already used in RedditModLog.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Enhanced Docker image configuration with OCI-compliant metadata labels, including title, description, authors, source, documentation, licenses, vendor, and base image information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->