### PR TITLE
chore(deps): bump apprise to 0.9.9 and click to 8.3.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 Flask==3.1.3
 requests==2.32.4
-apprise==0.9.5.1
+apprise==0.9.9
 Werkzeug==3.1.6
 Jinja2==3.1.6
 itsdangerous==2.2.0
-click==8.1.8
+click==8.3.1
 MarkupSafe==3.0.2
 blinker==1.9.0


### PR DESCRIPTION
## Summary
- apprise 0.9.5.1 → 0.9.9
- click 8.1.8 → 8.3.1

Supersedes closed PRs #20 and #21.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated apprise and click library versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->