### PR TITLE
fix: prevent X-Forwarded-For IP spoofing

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The Cloudflare DNS Updater (AutoDNS) is a Flask-based application designed to au
 
 ## Features
 
-- **Automatic IP Detection:** Automatically determines the IP address from incoming requests, including handling of `X-Forwarded-For` headers for proxied requests.
+- **Automatic IP Detection:** Determines the client IP from incoming requests. When behind a trusted reverse proxy, trusts `X-Forwarded-For` only from configured proxy IPs.
 - **GUID-based Identification:** Securely identifies the DNS record to update using GUIDs.
 - **Notifications:** Sends notifications through a variety of services using Apprise upon successful updates or errors.
 
@@ -20,6 +20,7 @@ Before you begin, ensure you have met the following requirements:
 - `CF_ZONE_ID` - Cloudflare Zone ID for the DNS records you are updating.
 - `CF_API_TOKEN` - API token used to authenticate with Cloudflare’s API.
 - `APPRISE_URLS`- Comma-separated URLs for notification services
+- `TRUSTED_PROXIES` - Comma-separated IPs of trusted reverse proxies. When set, `X-Forwarded-For` is only trusted from these IPs. When empty, `remote_addr` is always used.
 
 ```shell
 docker run -d \
@@ -32,5 +33,6 @@ docker run -d \
   -e APPRISE_URLS="your-apprise-urls-separated-by-commas" \
   -e AUTODNS_PORT=4295 \
   -e AUTODNS_HOST=0.0.0.0 \
+  -e TRUSTED_PROXIES="" \
   ghcr.io/baker-scripts/autodns:develop
 ```

--- a/autodns.py
+++ b/autodns.py
@@ -27,7 +27,6 @@ import json
 import os
 import requests
 import sys
-import time
 from datetime import datetime, timedelta
 from flask import Flask, request, jsonify
 import apprise
@@ -41,14 +40,35 @@ app = Flask(__name__)
 CF_ZONE_ID = os.getenv("CF_ZONE_ID")
 CF_API_TOKEN = os.getenv("CF_API_TOKEN")
 CF_API_URL_BASE = f"https://api.cloudflare.com/client/v4/zones/{CF_ZONE_ID}/dns_records"
-ENABLE_NOTIFICATIONS = os.getenv("ENABLE_NOTIFICATIONS", "false").lower() in ["true", "1", "t"]
+ENABLE_NOTIFICATIONS = os.getenv("ENABLE_NOTIFICATIONS", "false").lower() in [
+    "true",
+    "1",
+    "t",
+]
 APPRISE_URLS = os.getenv("APPRISE_URLS", "").split(",")
-MAPPING_FILE = '/config/guid_mapping.json'
+TRUSTED_PROXIES = {
+    ip.strip() for ip in os.getenv("TRUSTED_PROXIES", "").split(",") if ip.strip()
+}
+MAPPING_FILE = "/config/guid_mapping.json"
+
+
+def get_client_ip():
+    """Extract the real client IP from the request.
+
+    Only trusts X-Forwarded-For when the immediate connection comes from a
+    configured trusted proxy. Otherwise falls back to remote_addr.
+    """
+    if TRUSTED_PROXIES and request.remote_addr in TRUSTED_PROXIES:
+        forwarded = request.headers.get("X-Forwarded-For", "")
+        if forwarded:
+            return forwarded.split(",")[0].strip()
+    return request.remote_addr
+
 
 def load_guid_mapping():
     """Load GUID to A record mapping and last update timestamps from a JSON file."""
     try:
-        with open(MAPPING_FILE, 'r') as file:
+        with open(MAPPING_FILE, "r") as file:
             return json.load(file)
     except FileNotFoundError:
         return {}
@@ -57,18 +77,21 @@ def load_guid_mapping():
     except Exception as e:
         sys.exit(f"Error loading GUID mapping: {e}")
 
+
 def save_guid_mapping(mapping):
     """Save the updated GUID mapping and timestamps back to the JSON file."""
     try:
-        with open(MAPPING_FILE, 'w') as file:
+        with open(MAPPING_FILE, "w") as file:
             json.dump(mapping, file, indent=4)
     except Exception as e:
         sys.exit(f"Error saving GUID mapping: {e}")
+
 
 def generate_guid(subdomain):
     """Generate a 64-character SHA-256 hash GUID based on subdomain and current time."""
     unique_string = f"{subdomain}"
     return hashlib.sha256(unique_string.encode()).hexdigest()
+
 
 def is_update_allowed(guid):
     """Check if the update is allowed based on the last updated timestamp."""
@@ -77,6 +100,7 @@ def is_update_allowed(guid):
         return True
     last_update = datetime.fromisoformat(mapping[guid]["lastUpdated"])
     return datetime.now() - last_update > timedelta(minutes=RATE_LIMIT_MINUTES)
+
 
 def send_notification(message):
     """Send notification using Apprise if notifications are enabled and configured."""
@@ -93,6 +117,7 @@ def send_notification(message):
     else:
         print("Failed to send notification.")
 
+
 @app.route("/update-dns", methods=["GET"])
 def update_dns_web():
     """Web endpoint to update DNS record based on GUID and detected IP."""
@@ -102,36 +127,55 @@ def update_dns_web():
     mapping = load_guid_mapping()
     if guid not in mapping or not is_update_allowed(guid):
         return jsonify({"error": "Update not allowed or unknown GUID"}), 429
-    new_ip = request.headers.get('X-Forwarded-For', request.remote_addr).split(',')[0]
+    new_ip = get_client_ip()
 
-    headers = {"Authorization": f"Bearer {CF_API_TOKEN}", "Content-Type": "application/json"}
+    headers = {
+        "Authorization": f"Bearer {CF_API_TOKEN}",
+        "Content-Type": "application/json",
+    }
     dns_record = mapping[guid]["subdomain"]
     data = {"type": "A", "name": dns_record, "content": new_ip, "ttl": 1}
 
-    response = requests.get(f"{CF_API_URL_BASE}?name={dns_record}&type=A", headers=headers)
+    response = requests.get(
+        f"{CF_API_URL_BASE}?name={dns_record}&type=A", headers=headers
+    )
     if response.status_code == 200 and response.json()["result"]:
         dns_record_id = response.json()["result"][0]["id"]
-        update_response = requests.put(f"{CF_API_URL_BASE}/{dns_record_id}", headers=headers, json=data)
+        update_response = requests.put(
+            f"{CF_API_URL_BASE}/{dns_record_id}", headers=headers, json=data
+        )
         if update_response.status_code == 200:
             mapping[guid]["lastUpdated"] = datetime.now().isoformat()
             save_guid_mapping(mapping)
-            send_notification(f"DNS record for {dns_record} updated successfully to {new_ip}.")
+            send_notification(
+                f"DNS record for {dns_record} updated successfully to {new_ip}."
+            )
             return jsonify({"success": True, "message": "DNS record updated."})
         else:
             return jsonify({"error": "Failed to update DNS record."}), 500
     else:
-        return jsonify({"error": "DNS record does not exist or Cloudflare API error."}), 404
+        return jsonify(
+            {"error": "DNS record does not exist or Cloudflare API error."}
+        ), 404
+
 
 def parse_arguments():
     """Parse command line arguments for the DNS management script."""
-    parser = argparse.ArgumentParser(description="Manage DNS records via Cloudflare API.")
+    parser = argparse.ArgumentParser(
+        description="Manage DNS records via Cloudflare API."
+    )
     subparsers = parser.add_subparsers(dest="command", help="Available commands")
 
-    generate_parser = subparsers.add_parser("generate", help="Generate a new GUID for a subdomain")
-    generate_parser.add_argument("subdomain", type=str, help="Subdomain for which to generate a GUID")
+    generate_parser = subparsers.add_parser(
+        "generate", help="Generate a new GUID for a subdomain"
+    )
+    generate_parser.add_argument(
+        "subdomain", type=str, help="Subdomain for which to generate a GUID"
+    )
     generate_parser.set_defaults(func=handle_generate_command)
 
     return parser.parse_args()
+
 
 def handle_generate_command(args):
     """Handle the 'generate' command to create a new GUID for a subdomain."""
@@ -146,15 +190,18 @@ def handle_generate_command(args):
     print(f"Generated GUID for {subdomain}: {guid}")
     send_notification(f"Generated new GUID for {subdomain}.")
 
+
 def main():
     """Main function to run the Flask app or handle CLI commands."""
     args = parse_arguments()
-    if hasattr(args, 'func'):
+    if hasattr(args, "func"):
         args.func(args)
     else:
         # Run autodns daemon by default
         port = int(os.getenv("AUTODNS_PORT", "5000"))
         listen_on = os.getenv("AUTODNS_HOST", "0.0.0.0")
         app.run(host=listen_on, port=port)
-        if name == "main":
-            main()
+
+
+if __name__ == "__main__":
+    main()

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -11,4 +11,5 @@ services:
     - APPRISE_URLS: "your-apprise-urls-separated-by-commas"
     - AUTODNS_PORT: 4295
     - AUTODNS_HOST: 0.0.0.0 # Any IPv4
+    - TRUSTED_PROXIES: "" # Comma-separated IPs of trusted reverse proxies (e.g. "172.23.0.2,10.0.0.1")
     restart: unless-stopped


### PR DESCRIPTION
## Summary
- Added `TRUSTED_PROXIES` env var to configure which proxy IPs are trusted
- `X-Forwarded-For` is only honored when request comes from a trusted proxy IP
- When `TRUSTED_PROXIES` is empty (default), `remote_addr` is always used
- Fixed `__name__` guard (was `if name == "main"` — unreachable code)
- Removed unused `time` import

## Security
Previously, any client could send `X-Forwarded-For: <attacker-ip>` and redirect DNS A records to arbitrary IPs. This was exploitable by anyone who knew a valid GUID.

## Test plan
- [ ] Deploy with `TRUSTED_PROXIES` unset — verify `remote_addr` is used
- [ ] Deploy with `TRUSTED_PROXIES=172.23.0.2` — verify X-Forwarded-For is trusted from that IP only
- [ ] Send spoofed X-Forwarded-For from non-trusted IP — verify it is ignored

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added trusted proxy IP configuration for accurate client IP detection behind reverse proxies.
  * Added Apprise-based notification system for DNS update events.

* **Documentation**
  * Updated documentation for TRUSTED_PROXIES environment variable configuration.

* **Refactor**
  * Improved JSON error handling and request processing robustness.
  * Enhanced CLI argument parsing with clearer help text.
  * Improved DNS update response messages and error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->